### PR TITLE
Update the correct model import for metric depth estimation

### DIFF
--- a/metric_depth/README.md
+++ b/metric_depth/README.md
@@ -34,7 +34,7 @@ Download the checkpoints listed [here](#pre-trained-models) and put them under t
 import cv2
 import torch
 
-from depth_anything_v2.dpt import DepthAnythingV2
+from metric_depth.depth_anything_v2.dpt import DepthAnythingV2
 
 model_configs = {
     'vits': {'encoder': 'vits', 'features': 64, 'out_channels': [48, 96, 192, 384]},


### PR DESCRIPTION
I update the model import instruction from `from depth_anything_v2.dpt import DepthAnythingV2` to `from metric_depth.depth_anything_v2.dpt import DepthAnythingV2`, as the model in `depth_anything_v2.dpt` does not contain the attribute `max_depth`.