### PR TITLE
set pos interpolate mode to bilinear to support mps device

### DIFF
--- a/depth_anything_v2/dinov2.py
+++ b/depth_anything_v2/dinov2.py
@@ -200,7 +200,7 @@ class DinoVisionTransformer(nn.Module):
             patch_pos_embed.reshape(1, int(sqrt_N), int(sqrt_N), dim).permute(0, 3, 1, 2),
             scale_factor=(sx, sy),
             # (int(w0), int(h0)), # to solve the upsampling shape issue
-            mode="bicubic",
+            mode="bicubic" if x.device.type != "mps" else "bilinear",
             antialias=self.interpolate_antialias
         )
         


### PR DESCRIPTION
Torch doesn't support bicubic interpolation yet.

I tested it on m2 mac book air with torch 2.3.1 version.

<img width="963" alt="image" src="https://github.com/DepthAnything/Depth-Anything-V2/assets/35001605/5166d883-5d95-445e-8201-3b72e7da8603">
