### PR TITLE
Integrate with huggingface

### DIFF
--- a/depth_anything_v2/dpt.py
+++ b/depth_anything_v2/dpt.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.transforms import Compose
+from huggingface_hub import PyTorchModelHubMixin
 
 from .dinov2 import DINOv2
 from .util.blocks import FeatureFusionBlock, _make_scratch
@@ -150,7 +151,11 @@ class DPTHead(nn.Module):
         return out
 
 
-class DepthAnythingV2(nn.Module):
+class DepthAnythingV2(nn.Module,
+                      PyTorchModelHubMixin,
+                      tags=["depth","relative depth"],
+                      pipeline_tag="depth-estimation"
+                      ):
     def __init__(
         self, 
         encoder='vitl', 

--- a/depth_anything_v2/dpt.py
+++ b/depth_anything_v2/dpt.py
@@ -154,7 +154,9 @@ class DPTHead(nn.Module):
 class DepthAnythingV2(nn.Module,
                       PyTorchModelHubMixin,
                       tags=["depth","relative depth"],
-                      pipeline_tag="depth-estimation"
+                      pipeline_tag="depth-estimation",
+                      library_name="Depth-Anything-V2",
+                      repo_url="https://github.com/DepthAnything/Depth-Anything-V2",
                       ):
     def __init__(
         self, 


### PR DESCRIPTION
This pr mainly introduces a better way to push and load AI models from HuggingFace with ease using PyTorchModelHubMixin adding 3 methods to your model similar to how the transformers model operates which are : 
* save_pretrained
* push_to_hub
* from_pretrained (can work both locally and to load models from the hub)

## perks of using PyTorchModelHubMixin : 
* Easily save, share, and load your model
* This will bring back the download metrics (currently they are turned off in your HF repo )
* automatically add metadata to your repo allowing you to keep track of how many `Depth-Anything-V2` models exist on huggingface using the link : https://huggingface.co/models?other=Depth-Anything-V2 
* Optional: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "Depth-Anything-V2 " library official on the Hub meaning better discoverability + possibility to add code snippets.

you can also take a look at this colab notebook to set your huggingface repositories https://colab.research.google.com/drive/14jr-G280COi7YrFLtDp0J6VhBbTMgIZx?usp=sharing .
Once this is all done all users can load your model using the following code : 
```python
# no more initializing the model nor downloading the weights 
# or injecting the weights manually as this is all done automatically

model = DepthAnythingV2.from_pretrained("not-lain/Depth-Anything-V2-Small") # or any other repo
``` 