### PR TITLE
[Fix] image size before feeding into model

### DIFF
--- a/metric_depth/depth_to_pointcloud.py
+++ b/metric_depth/depth_to_pointcloud.py
@@ -40,6 +40,8 @@ def main():
                         help='Path to the pre-trained model weights.')
     parser.add_argument('--max-depth', default=20, type=float,
                         help='Maximum depth value for the depth map.')
+    parser.add_argument('--input-size', type=int, default=518,
+                        help='Input image size for model, which different from the raw image resolution.')
     parser.add_argument('--img-path', type=str, required=True,
                         help='Path to the input image or directory containing images.')
     parser.add_argument('--outdir', type=str, default='./vis_pointcloud',
@@ -90,16 +92,13 @@ def main():
 
         # Read the image using OpenCV
         image = cv2.imread(filename)
-        pred = depth_anything.infer_image(image, height)
-
-        # Resize depth prediction to match the original image size
-        resized_pred = Image.fromarray(pred).resize((width, height), Image.NEAREST)
+        pred = depth_anything.infer_image(image, args.input_size)
 
         # Generate mesh grid and calculate point cloud coordinates
         x, y = np.meshgrid(np.arange(width), np.arange(height))
         x = (x - width / 2) / args.focal_length_x
         y = (y - height / 2) / args.focal_length_y
-        z = np.array(resized_pred)
+        z = pred
         points = np.stack((np.multiply(x, z), np.multiply(y, z), z), axis=-1).reshape(-1, 3)
         colors = np.array(color_image).reshape(-1, 3) / 255.0
 


### PR DESCRIPTION
Hi 👋 !

Thx for your great work in monocular depth estimation and the results in my side is quite amazing! 🎉 

In this PR：

1. I fixed the issue with the input model image size.
    Previously, the height of the raw image was used for resizing ([See](https://github.com/DepthAnything/Depth-Anything-V2/blob/31dc97708961675ce6b3a8d8ffa729170a4aa273/metric_depth/depth_to_pointcloud.py#L93)),  and if the resolution of the raw image is large, the program would run out of memory (OOM).

2.  Also I removed some redundant code from the script. 
     For `depth_pred`, the original script performed a resize to match the resolution of `depth_pred` with that of the raw image ([See](https://github.com/DepthAnything/Depth-Anything-V2/blob/31dc97708961675ce6b3a8d8ffa729170a4aa273/metric_depth/depth_to_pointcloud.py#L96)). This operation has already been implemented in [here](https://github.com/DepthAnything/Depth-Anything-V2/blob/31dc97708961675ce6b3a8d8ffa729170a4aa273/depth_anything_v2/dpt.py#L211) and [here](https://github.com/DepthAnything/Depth-Anything-V2/blob/31dc97708961675ce6b3a8d8ffa729170a4aa273/depth_anything_v2/dpt.py#L192). 

 I would greatly appreciate it if PR could be accepted! Any code suggestions would be appreciated! 😄