### PR TITLE
image2tensor select correct device for multi-gpu setup

### DIFF
--- a/depth_anything_v2/dpt.py
+++ b/depth_anything_v2/dpt.py
@@ -214,8 +214,7 @@ class DepthAnythingV2(nn.Module):
         
         image = transform({'image': image})['image']
         image = torch.from_numpy(image).unsqueeze(0)
-        
-        DEVICE = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
+        DEVICE = next(self.pretrained.parameters()).device
         image = image.to(DEVICE)
         
         return image, (h, w)


### PR DESCRIPTION
image2tensor used a hardcoded device, which could mismatch the model's device in multi-GPU setups (for example: 'cuda' in image2tensor vs model on 'cuda:1'). Now it infers the model's device and moves the tensor accordingly.