### PR TITLE
Issues #297 and #296 have been resolved through dependency management and version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gradio_imageslider
-gradio==4.29.0
+gradio
 matplotlib
 opencv-python
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 opencv-python
 torch
 torchvision
+opencv-python-headless


### PR DESCRIPTION
Resolve this issue by installing the dependency: pip install opencv-python-headless