### PR TITLE
Fix get_cmap - ported to new version of matplotlib

### DIFF
--- a/metric_depth/run.py
+++ b/metric_depth/run.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     
     os.makedirs(args.outdir, exist_ok=True)
     
-    cmap = matplotlib.colormaps.get_cmap('Spectral')
+    cmap = matplotlib.colormaps['Spectral']
     
     for k, filename in enumerate(filenames):
         print(f'Progress {k+1}/{len(filenames)}: {filename}')

--- a/run.py
+++ b/run.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     
     os.makedirs(args.outdir, exist_ok=True)
     
-    cmap = matplotlib.colormaps.get_cmap('Spectral_r')
+    cmap = matplotlib.colormaps['Spectral']
     
     for k, filename in enumerate(filenames):
         print(f'Progress {k+1}/{len(filenames)}: {filename}')

--- a/run_video.py
+++ b/run_video.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     os.makedirs(args.outdir, exist_ok=True)
     
     margin_width = 50
-    cmap = matplotlib.colormaps.get_cmap('Spectral_r')
+    cmap = matplotlib.colormaps['Spectral']
     
     for k, filename in enumerate(filenames):
         print(f'Progress {k+1}/{len(filenames)}: {filename}')


### PR DESCRIPTION
Since version 3.9 of Matplotlib, colormap must be retrieved as a dictionary.