### PR TITLE
fix: respect model device in image preprocessing

### DIFF
--- a/depth_anything_v2/dpt.py
+++ b/depth_anything_v2/dpt.py
@@ -215,7 +215,6 @@ class DepthAnythingV2(nn.Module):
         image = transform({'image': image})['image']
         image = torch.from_numpy(image).unsqueeze(0)
         
-        DEVICE = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
-        image = image.to(DEVICE)
+        image = image.to(next(self.parameters()).device)
         
         return image, (h, w)

--- a/metric_depth/depth_anything_v2/dpt.py
+++ b/metric_depth/depth_anything_v2/dpt.py
@@ -216,7 +216,6 @@ class DepthAnythingV2(nn.Module):
         image = transform({'image': image})['image']
         image = torch.from_numpy(image).unsqueeze(0)
         
-        DEVICE = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
-        image = image.to(DEVICE)
+        image = image.to(next(self.parameters()).device)
         
         return image, (h, w)


### PR DESCRIPTION
## Bug
`image2tensor` in both `depth_anything_v2/dpt.py` and `metric_depth/depth_anything_v2/dpt.py` hardcodes device selection via `torch.cuda.is_available()` instead of using the model's actual device. This causes device mismatch errors when the model is on a different device (e.g., MPS, a specific CUDA GPU, or CPU when CUDA is available but the model was intentionally placed on CPU).

## Fix
Replaced the hardcoded device detection with `next(self.parameters()).device` to infer the device directly from the model's parameters. This ensures the input tensor is always placed on the same device as the model, regardless of how the model was loaded or moved.