### PR TITLE
fix: add NPU device detection in image2tensor to fix device mismatch

### DIFF
--- a/depth_anything_v2/dpt.py
+++ b/depth_anything_v2/dpt.py
@@ -215,7 +215,7 @@ class DepthAnythingV2(nn.Module):
         image = transform({'image': image})['image']
         image = torch.from_numpy(image).unsqueeze(0)
         
-        DEVICE = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
+        DEVICE = 'npu' if hasattr(torch, 'npu') and torch.npu.is_available() else 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
         image = image.to(DEVICE)
         
         return image, (h, w)


### PR DESCRIPTION
Resolve the following error:
<img width="1440" height="21" alt="image" src="https://github.com/user-attachments/assets/fd4802b0-dfe5-4046-8161-de59c80303d2" />
